### PR TITLE
Upgrade TypeScript and modernize practices

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "parcel-bundler": "^1.10.3",
     "sourcegraph": "^23.0.1",
     "tslint": "^5.11.0",
-    "typescript": "^3.7.3"
+    "typescript": "^3.7.4"
   },
   "dependencies": {
     "@sourcegraph/prettierrc": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5302,10 +5302,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.7.3:
-  version "3.7.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
-  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
+typescript@^3.7.4:
+  version "3.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.4.tgz#1743a5ec5fef6a1fa9f3e4708e33c81c73876c19"
+  integrity sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==
 
 uncss@^0.17.2:
   version "0.17.2"


### PR DESCRIPTION
- Use nullish coalescing, prefer readonly, and other TypeScript eslint fixes
- Upgrade TypeScript to a version that definitely supports these new features